### PR TITLE
skip null values in cache

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -44,6 +44,9 @@ func retrieveAndCache[T, U any](cda *Adapter[T], key string, retrieveFn func() (
 	go func() {
 		asStr, err := json.Marshal(resultFromDb)
 		if err == nil {
+			if string(asStr) == "null" || string(asStr) == "" {
+				return // Skip caching for empty or null values
+			}
 			go cda.redisClient.Set(ctx, key, asStr, cda.cacheTTL)
 		}
 


### PR DESCRIPTION
This pull request introduces a small but important change to the caching logic in `cache.go`. The change ensures that empty or null values are not cached, improving the efficiency and correctness of the caching mechanism.

* [`cache.go`](diffhunk://#diff-b2eb74c816d6381ef0c5306d99c2ba6de8fc5538f5dc57535d7fd7dc36153042R47-R49): Added a check to skip caching if the serialized result is either "null" or an empty string.