### PR TITLE
use QueryExecModeSimpleProtocol

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -69,7 +69,16 @@ func NewAdapter[T any](config Config[T]) (*Adapter[T], error) {
 	}
 
 	ctx := context.Background()
-	psqlConn, err := pgxpool.New(ctx, connUrl.String())
+	pgxConfig, err := pgxpool.ParseConfig(connUrl.String())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse postgres config: %w", err)
+	}
+	// Avoid "prepared statement already in use" (SQLSTATE 08P01) when pgxpool
+	// reuses a connection through PgBouncer transaction pooling. SimpleProtocol
+	// skips named Parse messages entirely, so no statement name collisions occur.
+	pgxConfig.ConnConfig.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+
+	psqlConn, err := pgxpool.NewWithConfig(ctx, pgxConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request updates the way PostgreSQL connections are created in the `NewAdapter` function to improve compatibility with PgBouncer transaction pooling and prevent prepared statement errors. The most important changes are:

PostgreSQL connection handling:

* Switched from using `pgxpool.New` to parsing the config with `pgxpool.ParseConfig` and then using `pgxpool.NewWithConfig`, allowing for more granular connection setup.
* Set `DefaultQueryExecMode` to `pgx.QueryExecModeSimpleProtocol` to avoid "prepared statement already in use" errors when PgBouncer is used in transaction pooling mode. This disables prepared statements and prevents statement name collisions.
* Improved error handling by adding a specific error message if parsing the PostgreSQL config fails.